### PR TITLE
Remove `dev` flag from setup install commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@
 
 ```bash
 # pnpm
-pnpm add -D nuxt-gtag
+pnpm add nuxt-gtag
 
 # npm
-npm i -D nuxt-gtag
+npm i nuxt-gtag
 ```
 
 ## Basic Usage


### PR DESCRIPTION
### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)

### 📚 Description

Arguably, the code provided when using this plugin runs in the client/within the production bundle and therefore should count as a "full" dependency?

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
