### PR TITLE
feat: track route changes automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 - 🌻 No dependencies except Google's `gtag.js`
 - 🤝 Manual [consent management](#consent-management) for GDPR compliance
 - 📯 Track events manually with [composables](#composables)
+- 🔍 [Track page views](#module-options) automatically as the route changes
 - 🏷️ Fully typed `gtag.js` API
 - 🦾 SSR-ready
 - 📂 [`.env` file support](#configuration)
@@ -124,14 +125,31 @@ function acceptTracking() {
 }
 ```
 
+### Automatic Route Tracking
+
+The module can listen to the active route and automatically send a `page_view` event (with path/title) whenever the user changes routes. By default, this functionality is disabled. To enable this feature, set the `enableAutomaticRouteTracking` option to `true`.
+
+```ts
+// `nuxt.config.ts`
+export default defineNuxtConfig({
+  modules: ['nuxt-gtag'],
+
+  gtag: {
+    id: 'G-XXXXXXXXXX',
+    enableAutomaticRouteTracking: true
+  }
+})
+```
+
 ## Module Options
 
-| Option | Type | Default | Description |
-| --- | --- | --- | --- |
-| `id` | `string` | `undefined` | The Google Analytics measurement ID. |
-| `config` | `Record<string, any>` | `{}` | The [configuration parameters](https://developers.google.com/analytics/devguides/collection/ga4/reference/config) to be passed to `gtag.js` on initialization. |
-| `initialConsent` | `boolean` | `true` | Whether to initially consent to tracking. |
-| `loadingStrategy` | `'async' \| 'defer'` | `'defer'` | The loading strategy to be used for the `gtag.js` script. |
+| Option            | Type | Default | Description                                                                                                                                                    |
+|-------------------| --- | --- |----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `id`              | `string` | `undefined` | The Google Analytics measurement ID.                                                                                                                           |
+| `config`          | `Record<string, any>` | `{}` | The [configuration parameters](https://developers.google.com/analytics/devguides/collection/ga4/reference/config) to be passed to `gtag.js` on initialization. |
+| `initialConsent`  | `boolean` | `true` | Whether to initially consent to tracking.                                                                                                                      |
+| `loadingStrategy` | `'async' \| 'defer'` | `'defer'` | The loading strategy to be used for the `gtag.js` script.                                                                                                      |
+| `enableAutomaticRouteTracking`          | `boolean` | `false` | Whether to automatically track page views.                                                                                              |
 
 ## Composables
 
@@ -291,6 +309,7 @@ useTrackEvent('login', {
 
 - [Maronbeere](https://maronbeere.carrd.co) for his logo pixel art.
 - [Junyoung Choi](https://github.com/rokt33r) and [Lucas Akira Uehara](https://github.com/KsAkira10) for their Google [`gtag.js` API type definitions](https://www.npmjs.com/package/@types/gtag.js)
+- [Simon Le Marchant](https://marchantweb.com) for contributing automatic route tracking.
 
 ## License
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -40,6 +40,16 @@ export interface ModuleOptions {
    * @default 'defer'
    */
   loadingStrategy?: 'async' | 'defer'
+
+  /**
+   * Whether to automatically track page views.
+   *
+   * @remarks
+   * If set to `true`, a `page_view` event will be sent to Google Analytics 4 whenever the route changes.
+   *
+   * @default false
+   */
+  enableAutomaticRouteTracking?: boolean
 }
 
 export default defineNuxtModule<ModuleOptions>({
@@ -56,6 +66,7 @@ export default defineNuxtModule<ModuleOptions>({
     config: {},
     initialConsent: true,
     loadingStrategy: 'defer',
+    enableAutomaticRouteTracking: false,
   },
   setup(options, nuxt) {
     const { resolve } = createResolver(import.meta.url)

--- a/src/runtime/plugin.client.ts
+++ b/src/runtime/plugin.client.ts
@@ -1,16 +1,28 @@
 import type { ModuleOptions } from '../module'
 import { initGtag } from './gtag'
-import { defineNuxtPlugin, useHead, useRuntimeConfig } from '#imports'
+import { defineNuxtPlugin, useGtag, useHead, useRouter, useRuntimeConfig } from '#imports'
 
 export default defineNuxtPlugin({
   parallel: true,
   setup() {
-    const { id, config, initialConsent, loadingStrategy } = useRuntimeConfig().public.gtag as Required<ModuleOptions>
+    const { id, config, initialConsent, loadingStrategy, enableAutomaticRouteTracking } = useRuntimeConfig().public.gtag as Required<ModuleOptions>
 
     if (!id)
       return
 
     initGtag({ id, config })
+
+    // Set up automatic route tracking
+    const router = useRouter()
+    const { gtag } = useGtag()
+    router.afterEach(() => {
+      if (enableAutomaticRouteTracking) {
+        gtag('event', 'page_view', {
+          page_location: router.currentRoute.value.fullPath,
+          page_title: router.currentRoute.value.meta.title,
+        })
+      }
+    })
 
     if (!initialConsent)
       return


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

closes #37 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Adds automatic page view tracking _(disabled by default)_ to the module, so that it can act in a similar way to traditional GA page tracking snippets. It can be enabled using the config, and fires a `page_view` gtag `event` upon route change with the page path and title as event metadata. Updates `README.md` to document this functionality. No changes to any other existing functionality.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
