### PR TITLE
feat: Add default values for Consent Mode v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nuxt-gtag",
   "type": "module",
-  "version": "1.2.2-beta.0",
+  "version": "1.3.0",
   "packageManager": "pnpm@8.15.3",
   "description": "Natively integrates Google Tag into Nuxt",
   "author": "Johann Schopplich <pkg@johannschopplich.com>",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nuxt-gtag",
   "type": "module",
-  "version": "1.3.0",
+  "version": "1.2.1",
   "packageManager": "pnpm@8.15.3",
   "description": "Natively integrates Google Tag into Nuxt",
   "author": "Johann Schopplich <pkg@johannschopplich.com>",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nuxt-gtag",
   "type": "module",
-  "version": "1.2.1",
+  "version": "1.2.2-beta.0",
   "packageManager": "pnpm@8.15.3",
   "description": "Natively integrates Google Tag into Nuxt",
   "author": "Johann Schopplich <pkg@johannschopplich.com>",

--- a/src/runtime/gtag.ts
+++ b/src/runtime/gtag.ts
@@ -12,6 +12,15 @@ export function gtag(command: string, ...args: any[]) {
 export function initGtag({ tags }: { tags: GoogleTagOptions[] }) {
   window.dataLayer = window.dataLayer || []
 
+  // https://developers.google.com/tag-platform/security/guides/consent
+  gtag('consent', 'default', {
+    'ad_user_data': 'denied',
+    'ad_personalization': 'denied',
+    'ad_storage': 'denied',
+    'analytics_storage': 'denied',
+    'wait_for_update': 500,
+  });
+
   gtag('js', new Date())
   for (const tag of tags)
     gtag('config', tag.id, tag.config)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This change adds the missing default values for consent mode v2 
See more: https://developers.google.com/tag-platform/security/guides/consent?consentmode=basic

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
