### PR TITLE
fix: expose plugin types

### DIFF
--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -9,6 +9,10 @@ declare module '@nuxt/schema' {
   }
 }
 
+declare module '#app' {
+  interface NuxtApp { }
+}
+
 export interface GoogleTagOptions {
   /**
    * The Google tag ID to initialize.


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

Ensure that plugin types are exposed, as this was broken with the https://github.com/johannschopplich/nuxt-gtag/commit/2ec0f085cfd1e0acceb89bdcff0668a8a8524f88 change.

Since this plugin doesn't provide any object, I didn't extend the `NuxtApp` interface. I followed this [codebase](https://github.com/nuxt-modules/color-mode/blob/0aed5962b4b6e2880f90c713b6773624e276bcec/src/runtime/types.ts#L28).

If you want, I can also update the dependencies and increase the version, in the same way @junemolison did in his MR: #82.

EDIT:
Another solution would be to simply type the plugin:
```ts
import type { Plugin } from 'nuxt/app'

export default defineNuxtPlugin({
  parallel: true,
  setup() {},
}) as Plugin
```
