### PR TITLE
docs: describe Conditionally Enable Tracking in Different Environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,30 @@ const { gtag, initialize } = useGtag()
 </template>
 ```
 
+### Conditionally Enable Tracking in Different Environments
+
+While it may seem intuitive to use `enabled: process.env.NODE_ENV === 'production'` to conditionally enable the module based on the environment, it is not recommended, as the `enabled` option is used for a different purpose in this module.
+
+Instead, to disable tracking in development and enable it only in production, the Gtag ID can be added via a config variable only in production environment file (e.g., `.env.production`):
+
+```ini
+# Only add this in production env
+NUXT_PUBLIC_GTAG_ID=G-XXXXXXXXXX
+```
+
+And keep the id property empty in module configuration:
+
+```ts
+export default defineNuxtConfig({
+  modules: ['nuxt-gtag'],
+
+  gtag: {
+    // Keep the id property empty here
+    // ... other configuration options
+  }
+})
+```
+
 ### Multi-Tenancy Support
 
 You can even leave the Google tag ID in your Nuxt config blank and set it dynamically later in your application by passing your ID as the first argument to `initialize`. This is especially useful if you want to use a custom ID for each user or if your app manages multiple tenants.


### PR DESCRIPTION
### 🔗 Linked issue

resolves #44 

### 📚 Description

This PR addresses the issue of conditionally enabling the `gtag.js` script based on the environment without changing the module API. Instead of altering the module's functionality, this PR updates the documentation to provide a clear and correct approach for developers to achieve this behavior.

Key Changes:
- Added a new section in the `README` to explain how to conditionally load the `gtag.js` script based on the environment.
- Clarified that the `enabled` option should not be used to control environment-based loading, as it serves a different purpose.
- Provided examples and explanations on how to use the `NUXT_PUBLIC_GTAG_ID` environment variable to manage the Gtag ID dynamically.

By documenting this solution, we provide users with a clear and safe way to achieve environment-based script loading

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt Google Tag!
----------------------------------------------------------------------->
