### PR TITLE
perf: add preload for script

### DIFF
--- a/src/runtime/plugin.client.ts
+++ b/src/runtime/plugin.client.ts
@@ -22,6 +22,13 @@ export default defineNuxtPlugin({
     const strategy = options.loadingStrategy === 'async' ? 'async' : 'defer'
 
     useHead({
+      link: [
+        {
+          rel: 'preload',
+          as: 'script',
+          href: withQuery(options.url, { id: tags[0].id }),
+        },
+      ],
       script: [
         {
           'src': withQuery(options.url, { id: tags[0].id }),


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

Adds script preload in <head> to improve performance

Currently the gtag script is already loaded using `async` or `defer`, but still we cannot control the position of the `<script>` tag vs those injected by nuxt or other modules. The benefit of declaring `preload` in `link` is that the preload can start as early as possible, and won't be blocked by other `<script>`. 

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt Google Tag!
----------------------------------------------------------------------->
